### PR TITLE
Only install the recommended

### DIFF
--- a/bin/setup.bash
+++ b/bin/setup.bash
@@ -4,7 +4,7 @@ set -e -u
 set -x
 
 _main() {
-	softwareupdate --install --all
+	softwareupdate --install --recommended
 
 	install_git_pair
 	install_brew


### PR DESCRIPTION
This will avoid install the itunes etc. on a new Mac OS.
